### PR TITLE
Add DIONAEA_JSON option to sysconfig file

### DIFF
--- a/dionaea.run.j2
+++ b/dionaea.run.j2
@@ -63,6 +63,7 @@ setup_dionaea_conf () {
       sed -i "s/ident:.*/ident: \"${uid}\"/g" {{ dionaea_dir }}/etc/dionaea/ihandlers-available/hpfeeds.yaml
       sed -i "s/secret:.*/secret: \"${secret}\"/g" {{ dionaea_dir }}/etc/dionaea/ihandlers-available/hpfeeds.yaml
       sed -i "/^\s*dynip_resolve:/s/^/#/g" {{ dionaea_dir }}/etc/dionaea/ihandlers-available/hpfeeds.yaml
+      sed -i "s/port:.*/port: ${FEEDS_SERVER_PORT}/g" /opt/dionaea/etc/dionaea/ihandlers-available/hpfeeds.yaml
     fi
 
     popd

--- a/dionaea.sysconfig
+++ b/dionaea.sysconfig
@@ -7,6 +7,7 @@ IP_ADDRESS=
 
 CHN_SERVER="http://localhost"
 DEPLOY_KEY=""
+DIONAEA_JSON="/etc/dionaea/dionaea.json"
 
 # Network options
 LISTEN_ADDRESSES="0.0.0.0"


### PR DESCRIPTION
Adding this option will ensure the sample sysconfig file includes the DIONAEA_JSON variable with a sane default that matches with documentation example docker-compose.yml file. Setting this variable in this way will ensure dionaea writes out it's registration information somewhere persistent.