### PR TITLE
Sed quoting

### DIFF
--- a/dionaea.run.j2
+++ b/dionaea.run.j2
@@ -64,8 +64,7 @@ setup_dionaea_conf () {
       sed -i "s/secret:.*/secret: \"${secret}\"/g" {{ dionaea_dir }}/etc/dionaea/ihandlers-available/hpfeeds.yaml
       sed -i "/^\s*dynip_resolve:/s/^/#/g" {{ dionaea_dir }}/etc/dionaea/ihandlers-available/hpfeeds.yaml
       sed -i "s/port:.*/port: ${FEEDS_SERVER_PORT}/g" /opt/dionaea/etc/dionaea/ihandlers-available/hpfeeds.yaml
-      sed -i "s|tags:.*|tags: \[${TAGS}\]|g"
-      /opt/dionaea/etc/dionaea/ihandlers-available/hpfeeds.yaml
+      sed -i "s|tags:.*|tags: \[${TAGS}\]|g" /opt/dionaea/etc/dionaea/ihandlers-available/hpfeeds.yaml
     fi
 
     popd

--- a/dionaea.run.j2
+++ b/dionaea.run.j2
@@ -64,7 +64,8 @@ setup_dionaea_conf () {
       sed -i "s/secret:.*/secret: \"${secret}\"/g" {{ dionaea_dir }}/etc/dionaea/ihandlers-available/hpfeeds.yaml
       sed -i "/^\s*dynip_resolve:/s/^/#/g" {{ dionaea_dir }}/etc/dionaea/ihandlers-available/hpfeeds.yaml
       sed -i "s/port:.*/port: ${FEEDS_SERVER_PORT}/g" /opt/dionaea/etc/dionaea/ihandlers-available/hpfeeds.yaml
-      sed -i "s/tags:.*/tags: \[${TAGS}\]/g" /opt/dionaea/etc/dionaea/ihandlers-available/hpfeeds.yaml
+      sed -i "s|tags:.*|tags: \[${TAGS}\]|g"
+      /opt/dionaea/etc/dionaea/ihandlers-available/hpfeeds.yaml
     fi
 
     popd


### PR DESCRIPTION
This change will allow for all characters OTHER THAN pipes ('|') to be used in the sysconfig TAGS variable.