### PR TITLE
Dionaea default ssl

### DIFF
--- a/dionaea.run.j2
+++ b/dionaea.run.j2
@@ -49,6 +49,10 @@ setup_dionaea_conf () {
     sed -i "s/# listen.addresses=.*/listen.addresses=$LISTEN_ADDRESSES/g" dionaea.cfg
     sed -i "s/# listen.interfaces=.*/listen.interfaces=$LISTEN_INTERFACES/g" dionaea.cfg
     sed -i "s/default.levels=all/default.levels=all,-debug/g" dionaea.cfg
+    sed -i "s/# ssl.default.c=GB/ssl.default.c=US/" dionaea.cfg
+    sed -i "s/# ssl.default.cn=/ssl.default.cn=test.example.org/" dionaea.cfg
+    sed -i "s/# ssl.default.o=/ssl.default.o=example.org/" dionaea.cfg
+    sed -i "s/# ssl.default.ou=/ssl.default.ou=test" dionaea.cfg
 
     # Enable services
     #for i in ${SERVICES[@]}; do

--- a/dionaea.run.j2
+++ b/dionaea.run.j2
@@ -49,6 +49,10 @@ setup_dionaea_conf () {
     sed -i "s/# listen.addresses=.*/listen.addresses=$LISTEN_ADDRESSES/g" dionaea.cfg
     sed -i "s/# listen.interfaces=.*/listen.interfaces=$LISTEN_INTERFACES/g" dionaea.cfg
     sed -i "s/default.levels=all/default.levels=all,-debug/g" dionaea.cfg
+    sed -i "s/# ssl.default.c=GB/ssl.default.c=US/g" dionaea.cfg
+    sed -i "s/# ssl.default.cn=/ssl.default.cn=test.example.org/g" dionaea.cfg
+    sed -i "s/# ssl.default.o=/ssl.default.o=example.org/g" dionaea.cfg
+    sed -i "s/# ssl.default.ou=/ssl.default.ou=test/g" dionaea.cfg
 
     # Enable services
     #for i in ${SERVICES[@]}; do


### PR DESCRIPTION
This PR will make the default certificate more generic (and not call out dionaea in the cert). 

Ultimately it would be best to expose this config in a similar fashion to the cowrie personalities. 

Should resolve #22 