### PR TITLE
Added clear all logs if disk nearly full

### DIFF
--- a/clean_bistreams.sh
+++ b/clean_bistreams.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
-# Compress bistream files older than 5 minutes
-find /opt/dionaea/var/dionaea/bistreams/* -type f -mmin +5 -exec gzip {} \;
+CURRENT=$(df / | grep / | awk '{ print $5 }' | sed 's/%//g')
+THRESHOLD=95
 
-# Clear bistream logs from dionaea every 60 minutes
-find /opt/dionaea/var/dionaea/bistreams/* -type f -mmin +60 -exec rm {} \;
+# Compress bistream files older than 5 minutes
+find /opt/dionaea/var/dionaea/bistreams/* -name '*.gz' -type f -mmin +5 -exec gzip {} \;
+
+if [ "${CURRENT}" -gt "${THRESHOLD}" ] ; then
+  # Clear all bistream logs from dionaea if disk nearly full
+  find /opt/dionaea/var/dionaea/bistreams/* -type f -exec rm {} \;
+else
+  # Clear bistream logs from dionaea every 60 minutes
+  find /opt/dionaea/var/dionaea/bistreams/* -type f -mmin +60 -exec rm {} \;
+fi
+
 find /opt/dionaea/var/dionaea/bistreams/* -type d -empty -delete


### PR DESCRIPTION
This adds a failsafe of clearing all the logs if the disk is nearly full. This is useful on a small VPS as the disk often fills before 60 minutes.