### PR TITLE
Debian personality upgrade

### DIFF
--- a/dionaea.yml
+++ b/dionaea.yml
@@ -114,7 +114,7 @@
       - name: Dionaea | patch 0.80 for SIP file path
         lineinfile:
           path: "{{ dionaea_dir }}/lib/dionaea/python/dionaea/sip/extras.py"
-          regexp: '        self.users = os.path.join(self.root_path, config.get'
+          regexp: '        self.users = os.path.join\(self.root_path, config.get'
           line: '        self.users = os.path.join(self.root_path, config.get("users", "var/lib/dionaea/sip/sipaccounts.sqlite"))'
           owner: dionaea
           group: root

--- a/dionaea.yml
+++ b/dionaea.yml
@@ -111,6 +111,15 @@
           src: dionaea.sysconfig
           mode: 0644
 
+      - name: Dionaea | patch 0.80 for SIP file path
+        lineinfile:
+          path: "{{ dionaea_dir }}/lib/dionaea/python/dionaea/sip/extras.py"
+          regexp: '        self.users = os.path.join(self.root_path, config.get'
+          line: '        self.users = os.path.join(self.root_path, config.get("users", "var/lib/dionaea/sip/sipaccounts.sqlite"))'
+          owner: dionaea
+          group: root
+          mode: '0644'
+
       - name: Dionaea | create runit directories
         file:
           state: directory

--- a/personalities/debian/dionaea.cfg
+++ b/personalities/debian/dionaea.cfg
@@ -23,7 +23,7 @@ ssl.default.ou=test
 
 [logging]
 default.filename = var/log/dionaea/dionaea.log
-default.levels = all
+default.levels = all,-debug
 default.domains=*
 
 errors.filename = var/log/dionaea/dionaea-errors.log

--- a/personalities/debian/dionaea.cfg
+++ b/personalities/debian/dionaea.cfg
@@ -1,11 +1,16 @@
 [dionaea]
-download.dir=/opt/dionaea/var/dionaea/binaries/
+download.dir = var/lib/dionaea/binaries/
 modules=curl,python,nfq,emu,pcap
 processors=filter_streamdumper,filter_emu
 
 listen.mode=getifaddrs
 listen.addresses=0.0.0.0
 listen.interfaces=eth0
+
+# Use IPv4 mapped IPv6 addresses
+# It is not recommended to use this feature, try to use nativ IPv4 and IPv6 adresses
+# Valid values: true|false
+# listen.use_ipv4_mapped_ipv6=false
 
 # Country
 ssl.default.c=US
@@ -17,11 +22,11 @@ ssl.default.o=example.org
 ssl.default.ou=test
 
 [logging]
-default.filename=/opt/dionaea/var/dionaea/dionaea.log
-default.levels=all,-debug
+default.filename = var/log/dionaea/dionaea.log
+default.levels = all
 default.domains=*
 
-errors.filename=/opt/dionaea/var/dionaea/dionaea-errors.log
+errors.filename = var/log/dionaea/dionaea-errors.log
 errors.levels=warning,error
 errors.domains=*
 
@@ -40,7 +45,7 @@ next=streamdumper
 
 [processor.streamdumper]
 name=streamdumper
-config.path=/opt/dionaea/var/dionaea/bistreams/%Y-%m-%d/
+config.path = var/lib/dionaea/bistreams/%Y-%m-%d/
 
 [processor.emu]
 name=emu
@@ -65,9 +70,8 @@ lookup_ethernet_addr=no
 [module.python]
 imports=dionaea.log,dionaea.services,dionaea.ihandlers
 sys_paths=default
-service_configs=/opt/dionaea/etc/dionaea/services-enabled/*.yaml
-ihandler_configs=/opt/dionaea/etc/dionaea/ihandlers-enabled/*.yaml
+service_configs = etc/dionaea/services-enabled/*.yaml
+ihandler_configs = etc/dionaea/ihandlers-enabled/*.yaml
 
 [module.pcap]
 any.interface=any
-

--- a/personalities/debian/services-available/ftp.yaml
+++ b/personalities/debian/services-available/ftp.yaml
@@ -1,5 +1,5 @@
 - name: ftp
   config:
-    root: /opt/dionaea/var/dionaea/roots/ftp
+    root: "var/lib/dionaea/ftp/root"
     response_messages:
       welcome_msg: 220 ProFTPD 1.3.5e Server (Debian)

--- a/personalities/debian/services-available/http.yaml
+++ b/personalities/debian/services-available/http.yaml
@@ -1,6 +1,6 @@
 - name: http
   config:
-    root: "/opt/dionaea/var/dionaea/roots/www"
+    root: "var/lib/dionaea/http/root"
     ports:
       - 80
     ssl_ports:
@@ -21,7 +21,7 @@
       # this feature requires jinja2 template engine http://jinja.pocoo.org/
       enabled: false
       file_extension: .j2
-      path: "/opt/dionaea/var/dionaea/share/python/http/template/nginx"
+      path: "var/lib/dionaea/http/template/nginx"
       templates:
         autoindex:
           filename: autoindex.html.j2
@@ -30,4 +30,4 @@
           # - filename: error/{code}.html.j2
       # used to specify additional template values
       values:
-        # full_name: nginx/1.1
+        full_name: nginx/1.10.3

--- a/personalities/debian/services-available/pptp.yaml
+++ b/personalities/debian/services-available/pptp.yaml
@@ -11,9 +11,9 @@
 #    vendor_name: DrayTek
 
 # Linux
-#    firmware_revision: 1
-#    hostname: local
-#    vendor_name: linux
+    firmware_revision: 1
+    hostname: local
+    vendor_name: linux
 
 # Windows
 #    firmware_revision: 0

--- a/personalities/debian/services-available/sip.yaml
+++ b/personalities/debian/services-available/sip.yaml
@@ -6,7 +6,7 @@
       - 5060
     tls_ports:
       - 5061
-    users: "/opt/dionaea/var/dionaea/sipaccounts.sqlite"
+    users: "var/lib/dionaea/sip/accounts.sqlite"
     rtp:
       enable: true
       # how to dump the rtp stream
@@ -15,7 +15,7 @@
         - bistream
         - pcap
       pcap:
-        path: "var/dionaea/rtp/{personality}/%Y-%m-%d/"
+        path: "var/lib/dionaea/sip/rtp/{personality}/%Y-%m-%d/"
         filename: "%H:%M:%S_{remote_host}_{remote_port}_in.pcap"
     personalities:
       default:

--- a/personalities/debian/services-available/tftp.yaml
+++ b/personalities/debian/services-available/tftp.yaml
@@ -1,3 +1,3 @@
 - name: tftp
   config:
-    root: /opt/dionaea/var/dionaea/roots/tftp
+    root: "var/lib/dionaea/tftp/root"


### PR DESCRIPTION
This PR will fix the default alternate personality "debian" in the image. With the upgrade from .70 to .80 of dionaea the paths were changed.

Also included is an ansible-based fix for the hard coded path of SIP that will release in dionaea 0.90, included here as it's a simple fix.