### PR TITLE
Fix the path name of the bistreams log directory

### DIFF
--- a/clean_bistreams.sh
+++ b/clean_bistreams.sh
@@ -4,14 +4,14 @@ CURRENT=$(df / | grep / | awk '{ print $5 }' | sed 's/%//g')
 THRESHOLD=95
 
 # Compress bistream files older than 5 minutes
-find /opt/dionaea/var/dionaea/bistreams/* -type f -mmin +5 -exec gzip {} \;
+find /opt/dionaea/var/lib/dionaea/bistreams/* -type f -mmin +5 -exec gzip {} \;
 
 if [ "${CURRENT}" -gt "${THRESHOLD}" ] ; then
   # Clear all bistream logs from dionaea if disk nearly full
-  find /opt/dionaea/var/dionaea/bistreams/* -type f -exec rm {} \;
+  find /opt/dionaea/var/lib/dionaea/bistreams/* -type f -exec rm {} \;
 else
   # Clear bistream logs from dionaea every 60 minutes
-  find /opt/dionaea/var/dionaea/bistreams/* -type f -mmin +60 -exec rm {} \;
+  find /opt/dionaea/var/lib/dionaea/bistreams/* -type f -mmin +60 -exec rm {} \;
 fi
 
-find /opt/dionaea/var/dionaea/bistreams/* -type d -empty -delete
+find /opt/dionaea/var/lib/dionaea/bistreams/* -type d -empty -delete


### PR DESCRIPTION
I am using the dionaea container in my environment, and found that the bistreams log files were not compressed and removed.  It seems that the clean_bistreams.sh script is not looking for the correct directory path of the bitstreams files.